### PR TITLE
fix(zsh): repair three installer-induced .zshrc defects

### DIFF
--- a/shell/zsh/.zshrc
+++ b/shell/zsh/.zshrc
@@ -77,9 +77,20 @@ esac
 # ~/.zshrc.local に以下のような内容を記載:
 # export NVM_DIR="$HOME/.nvm"
 # [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
-[ -f ~/.zshrc.local ] && source ~/.zshrc.local [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+[ -f ~/.zshrc.local ] && source ~/.zshrc.local
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 
 
 
 
-. "$HOME/.local/bin/env"
+# uv(Astral)のインストーラが書く行。中身は ~/.local/bin を PATH に足すだけで、
+# ~/.zshrc.local の PATH 設定と重複している。uv を消すとこのファイルだけ残って
+# 毎回 "no such file or directory" が出るので存在チェックで囲う。
+[ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
+
+# Added by LM Studio CLI (lms)
+# 注: インストーラは /Users/ysn/... をハードコードで書き込む。
+# このrepoはWSL/Linuxでも使うので $HOME に直してある。lms再インストール時は再確認すること。
+[ -d "$HOME/.lmstudio/bin" ] && export PATH="$PATH:$HOME/.lmstudio/bin"
+# End of LM Studio CLI section
+


### PR DESCRIPTION
## 背景

新しいターミナルを開くたびに、毎回このエラーが出ていた。

```
/Users/ysn/.zshrc:.:86: no such file or directory: /Users/ysn/.local/bin/env
```

調べたところ、原因は3つ。いずれも**インストーラが `.zshrc` の末尾に無条件で追記した結果**で、同じパターンの事故だった。

## 変更内容

### 1. 改行抜けで2つの文が合体していた（既存のcommit済みバグ）

```sh
[ -f ~/.zshrc.local ] && source ~/.zshrc.local [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
```

`source ~/.zshrc.local` に `[ -s ... ]` が**位置引数として渡っていた**。今は偶然動いているが、`.zshrc.local` が `$@` を参照した瞬間に壊れる。2行に分離した。

### 2. uv の孤児行（冒頭のエラーの正体）

`. "$HOME/.local/bin/env"` は uv (Astral) のインストーラが書く行。uv をアンインストールした際にこの行だけ残り、参照先が存在しないため毎回エラーを出していた。

なお、このファイルの中身は `~/.local/bin` を PATH に足すだけで、`~/.zshrc.local` の PATH 設定と重複している。**動いていたとしても冗長**だった。

削除ではなく存在チェックで囲う方針にした。将来 uv を入れ直したら自動で復活するため。

### 3. LM Studio がハードコードした絶対パス

```diff
-export PATH="$PATH:/Users/ysn/.lmstudio/bin"
+[ -d "$HOME/.lmstudio/bin" ] && export PATH="$PATH:$HOME/.lmstudio/bin"
```

このリポジトリは CLAUDE.md にある通り Linux / WSL / macOS を対象にしているが、`/Users/ysn` 決め打ちでは macOS 以外で機能しない。`$HOME` に置き換え、ディレクトリが無いマシンでは PATH を汚さないようガードも追加した。

## 検証

| 項目 | 結果 |
|---|---|
| `zsh -n shell/zsh/.zshrc` | 構文OK |
| `zsh -l -i` で実際にログイン | **stderr への出力ゼロ** |
| PATH 解決 | `~/.local/bin`, `~/.lmstudio/bin` とも正常 |

## 備考

3件とも「インストーラによる `.zshrc` 末尾への無条件 append」が原因。cross-platform なリポジトリでは事故になりやすいため、各修正箇所に経緯をコメントとして残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
